### PR TITLE
Add GitHub workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt
+      - uses: actions/checkout@v2
+      - name: Run `cargo fmt`
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    needs: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: clippy
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run `cargo clippy`
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  build:
+    needs: clippy
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and run tests
+        run: |
+          cargo test --verbose


### PR DESCRIPTION
This worflow runs on every commit and PR on the `main` branch. It performs 3 jobs:

1. `rustfmt`: Checks if the code is formatted correctly
2. `clippy`: Checks if the code passes the clippy linter. It also displays all warnings and errors reported by clippy.
3. `build`: Runs `cargo test`. This fails if the code doesn't compile or if it doesn't pass all tests. It is run with the stable toolchain on three platforms:
   - ubuntu
   - macos
   - windows