### PR TITLE
Implemented piping and redirection

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -472,7 +472,7 @@ fn repl(
 /// If the expression can be executed as a program, then it will
 /// be stored in the `cmd` parameter, and the function will return
 /// `Ok(Some(cmd))`.
-/// 
+///
 /// Otherwise, the program will return `Ok(None)`.
 fn expr_to_command<'a>(
     cmd: &'a mut Command,
@@ -627,7 +627,7 @@ fn main() -> Result<(), Error> {
                                 // If it is not the last command, then we need
                                 // collect its standard output for the next process
                                 // in the pipe.
-                                
+
                                 // Attempt to grab the STDOUT of the process from the handler.
                                 if let Ok(output) = child_handler.wait_with_output() {
                                     // Store the contents of the STDOUT into the buffer
@@ -669,10 +669,7 @@ fn main() -> Result<(), Error> {
                             expr.clone()
                         } else {
                             // If this is any other command, pipe in the result of the last command (via application).
-                            Expression::Apply(
-                                Box::new(expr.clone()),
-                                vec![result_of_last_cmd],
-                            )
+                            Expression::Apply(Box::new(expr.clone()), vec![result_of_last_cmd])
                         }
                         .eval(env)?;
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -22,7 +22,9 @@ use rand::{distributions::Uniform, seq::SliceRandom, thread_rng, Rng};
 use std::{
     borrow::Cow::{self, Borrowed, Owned},
     env::current_exe,
+    io::Write,
     path::PathBuf,
+    process::{exit, Command, Stdio},
     sync::{Arc, Mutex},
     thread::sleep,
     time::Duration,
@@ -38,11 +40,11 @@ fn new_editor(env: &Environment) -> Editor<DuneHelper> {
         .auto_add_history(false)
         .completion_type(CompletionType::List)
         .edit_mode(EditMode::Emacs)
+        .check_cursor_position(true)
         .output_stream(OutputStreamType::Stdout)
         .build();
 
     let mut rl = Editor::with_config(config);
-
     let h = DuneHelper {
         completer: FilenameCompleter::new(),
         highlighter: MatchingBracketHighlighter::new(),
@@ -53,6 +55,21 @@ fn new_editor(env: &Environment) -> Editor<DuneHelper> {
     };
     rl.set_helper(Some(h));
     rl
+}
+
+fn readline(prompt: impl ToString, rl: &mut Editor<impl Helper>) -> String {
+    loop {
+        match rl.readline(&prompt.to_string()) {
+            Ok(line) => return line,
+            Err(ReadlineError::Interrupted) => {
+                return String::new();
+            }
+            Err(ReadlineError::Eof) => exit(0),
+            Err(err) => {
+                eprintln!("error: {:?}", err);
+            }
+        }
+    }
 }
 
 #[derive(Helper)]
@@ -260,21 +277,6 @@ impl Validator for DuneHelper {
     }
 }
 
-fn readline(prompt: impl ToString, rl: &mut Editor<impl Helper>) -> String {
-    loop {
-        match rl.readline(&prompt.to_string()) {
-            Ok(line) => return line,
-            Err(ReadlineError::Interrupted) => {
-                return String::new();
-            }
-            Err(ReadlineError::Eof) => std::process::exit(0),
-            Err(err) => {
-                eprintln!("error: {:?}", err);
-            }
-        }
-    }
-}
-
 fn get_os_name(t: &Type) -> String {
     match t {
         Type::Alpine => "alpine",
@@ -407,7 +409,7 @@ fn repl(
             vec![cwd.clone().into()],
         )
         .eval(&mut env)
-        .unwrap_or_else(|_| format!("{}$", cwd).into())
+        .unwrap_or_else(|_| format!("{}$ ", cwd).into())
         .to_string();
         rl.helper_mut()
             .expect("No helper")
@@ -466,8 +468,232 @@ fn repl(
     }
 }
 
+/// Interpret a Dune expression as a program to be executed.
+/// If the expression can be executed as a program, then it will
+/// be stored in the `cmd` parameter, and the function will return
+/// `Ok(Some(cmd))`.
+/// 
+/// Otherwise, the program will return `Ok(None)`.
+fn expr_to_command<'a>(
+    cmd: &'a mut Command,
+    expr: &Expression,
+    env: &mut Environment,
+) -> Result<Option<&'a mut Command>, Error> {
+    let bindings = env
+        .bindings
+        .clone()
+        .into_iter()
+        .map(|(k, v)| (k, v.to_string()))
+        // This is to prevent environment variables from getting too large.
+        // This causes some strange bugs on Linux: mainly it becomes
+        // impossible to execute any program because `the argument
+        // list is too long`.
+        .filter(|(_, s)| s.len() <= 1024);
+
+    Ok(match expr {
+        // If the command is quoted or in parentheses, try to get the inner command.
+        Expression::Group(expr) | Expression::Quote(expr) => expr_to_command(cmd, &expr, env)?,
+        // If the command is an undefined symbol with some arguments.
+        Expression::Apply(f, args) => match **f {
+            Expression::Symbol(ref name) if !env.is_defined(name) => {
+                *cmd = Command::new(name);
+                Some(
+                    cmd.current_dir(env.get_cwd()).envs(bindings).args(
+                        args.iter()
+                            .filter(|&x| x != &Expression::None)
+                            .map(|x| Ok(format!("{}", x.eval(env)?)))
+                            .collect::<Result<Vec<String>, Error>>()?,
+                    ),
+                )
+            }
+            _ => None,
+        },
+
+        // If the command is an undefined symbol, or an alias.
+        Expression::Symbol(name) => match env.get(name) {
+            // If the symbol is an alias, then execute the alias.
+            Some(Expression::Symbol(name)) => {
+                *cmd = Command::new(name);
+                Some(cmd.current_dir(env.get_cwd()).envs(bindings))
+            }
+            // If the symbol is bound to something like `5`, this isn't a command.
+            Some(_) => None,
+            // If the symbol is not defined, use the symbol as the program name.
+            None => {
+                *cmd = Command::new(name);
+                Some(cmd.current_dir(env.get_cwd()).envs(bindings))
+            }
+        },
+
+        // Other types of expressions cannot be commands.
+        _ => None,
+    })
+}
+
 fn main() -> Result<(), Error> {
     let mut env = Environment::new();
+    // This is a special form that takes a list of expressions
+    // and interprets them as a commands.
+    // It pipes the result of each command to the next one.
+    env.define_builtin(
+        "pipe",
+        |args, env| {
+            if args.len() <= 1 {
+                return Err(Error::CustomError(
+                    "pipe requires at least two arguments".to_string(),
+                ));
+            }
+            // The accumulator for the result of the pipe.
+            // This is mainly used if the user pipes into a command
+            // that is a function or macro like so:
+            //
+            // $ "Hello" | (x -> x + " world!") | echo
+            let mut result_of_last_cmd = Expression::None;
+            // The buffer of the STDOUT of the last command.
+            let mut buf = vec![];
+
+            // A dummy value to hold where `expr_to_command` stores its resulting command.
+            let mut x = Command::new("dummy");
+
+            // For every command, pipe in the previous output buffer,
+            // and get the result.
+            for (i, expr) in args.iter().enumerate() {
+                // Is this the first command to be executed?
+                let is_first = i == 0;
+                // Is this the last command to be executed?
+                let is_last = i == args.len() - 1;
+
+                // If the expression can be interpreted as a command (a call to a program),
+                // then execute it and get its standard output (using the last expression's
+                // result as the standard input).
+                match expr_to_command(&mut x, expr, env)? {
+                    // If the expression is a command:
+                    Some(mut cmd) => {
+                        if is_first {
+                            // If this is the first command, we inherit the current STDIN.
+                            cmd = cmd.stdin(Stdio::inherit());
+                        } else {
+                            // Otherwise, we use the piped STDOUT of the previous command.
+                            cmd = cmd.stdin(Stdio::piped());
+                        }
+
+                        if is_last {
+                            // If this is the last command, we inherit the current STDOUT.
+                            cmd = cmd.stdout(Stdio::inherit());
+                        } else {
+                            // Otherwise, we collect the stdout and pipe it to the next command.
+                            cmd = cmd.stdout(Stdio::piped());
+                        }
+
+                        // Try to execute the command.
+                        if let Ok(mut child_handler) = cmd.spawn() {
+                            // If we need to pipe in STDIN:
+                            if !is_first {
+                                // Attempt to grab the STDIN of the process from the handler.
+                                if let Some(stdin) = child_handler.stdin.as_mut() {
+                                    // Write the contents of the previous command's STDOUT
+                                    // to the process's STDIN.
+                                    if let Err(_) = stdin.write_all(&buf) {
+                                        return Err(Error::CustomError(format!(
+                                            "error when piping into process `{}`",
+                                            expr
+                                        )));
+                                    }
+
+                                    // Zero out all of our information about the previous command.
+                                    buf = vec![];
+                                    result_of_last_cmd = Expression::None;
+
+                                    // Flush the STDIN buffer to force the process to read it.
+                                    stdin.flush().unwrap();
+                                } else {
+                                    return Err(Error::CustomError(format!(
+                                        "error when piping into process `{}`",
+                                        expr
+                                    )));
+                                }
+                            }
+
+                            if is_last {
+                                // If this is the last command in the pipe, then simply
+                                // wait for it to finish without piping in any input.
+                                if let Err(_) = child_handler.wait() {
+                                    return Err(Error::CustomError(format!(
+                                        "error when waiting for process `{}`",
+                                        expr
+                                    )));
+                                }
+                            } else {
+                                // If it is not the last command, then we need
+                                // collect its standard output for the next process
+                                // in the pipe.
+                                
+                                // Attempt to grab the STDOUT of the process from the handler.
+                                if let Ok(output) = child_handler.wait_with_output() {
+                                    // Store the contents of the STDOUT into the buffer
+                                    // for the next process.
+                                    buf = output.stdout.clone();
+
+                                    // Store the result of the command into the accumulator.
+                                    result_of_last_cmd =
+                                        if let Ok(s) = String::from_utf8(output.stdout) {
+                                            // If the command returned valid UTF-8,
+                                            // then store it as a string.
+                                            Expression::String(s)
+                                        } else {
+                                            // Otherwise, store it as a list of bytes to
+                                            // prevent the loss of any data.
+                                            Expression::Bytes(buf.clone())
+                                        };
+                                } else {
+                                    return Err(Error::CustomError(format!(
+                                        "error when waiting for process `{}`",
+                                        expr
+                                    )));
+                                }
+                            }
+                        } else {
+                            // We couldn't spawn the command.
+                            return Err(Error::CustomError(format!(
+                                "could not spawn process `{}`",
+                                expr
+                            )));
+                        }
+                    }
+                    // If the expression is not a command, then
+                    // treat this as an application of that expression to the result
+                    // of the last command.
+                    None => {
+                        result_of_last_cmd = if is_first {
+                            // If this is the first command, don't pipe in anything.
+                            expr.clone()
+                        } else {
+                            // If this is any other command, pipe in the result of the last command (via application).
+                            Expression::Apply(
+                                Box::new(expr.clone()),
+                                vec![result_of_last_cmd.into()],
+                            )
+                        }
+                        .eval(env)?;
+
+                        if let Expression::Bytes(ref bytes) = result_of_last_cmd {
+                            // If the result of the last command was some bytes,
+                            // then store the bytes directly into the stdin buffer for the next command.
+                            buf = bytes.clone();
+                        } else {
+                            // Otherwise, just convert the result of this command into a string,
+                            // and store that into the stdin buffer for the next command.
+                            buf = result_of_last_cmd.to_string().into_bytes();
+                        }
+                    }
+                }
+            }
+            // Return the accumulated Dune expression.
+            Ok(result_of_last_cmd)
+        },
+        "pipe commands",
+    );
+
     env.define(
         "math",
         b_tree_map! {
@@ -675,7 +901,8 @@ fn main() -> Result<(), Error> {
     env.define(
         "shell",
         b_tree_map! {
-            String::from("author") => Expression::String("Adam McDaniel (adam-mcdaniel.net)".to_string()),
+            String::from("author") => Expression::String("Adam McDaniel (https://adam-mcdaniel.net)".to_string()),
+            String::from("git") => Expression::String("https://github.com/adam-mcdaniel/dune".to_string()),
             String::from("version") => Expression::String(VERSION.to_string()),
             String::from("path") => {
                 if let Ok(path) = current_exe() {
@@ -963,9 +1190,14 @@ fn main() -> Result<(), Error> {
                 let file = args[0].eval(env)?;
                 path = path.join(file.to_string());
 
-                match std::fs::read_to_string(path) {
+                match std::fs::read_to_string(&path) {
+                    // First, try to read the contents as a string.
                     Ok(contents) => Ok(contents.into()),
-                    Err(_) => Err(Error::CustomError(format!("could not read file {}", file)))
+                    // If that fails, try to read them as a list of bytes.
+                    Err(_) => match std::fs::read(&path) {
+                        Ok(contents) => Ok(Expression::Bytes(contents)),
+                        Err(_) => Err(Error::CustomError(format!("could not read file {}", file)))
+                    }
                 }
             }, "read a file"),
 
@@ -974,9 +1206,20 @@ fn main() -> Result<(), Error> {
                 let mut path = PathBuf::from(env.get_cwd());
                 let file = args[0].eval(env)?;
                 path = path.join(file.to_string());
-                match std::fs::write(path, args[1].eval(env)?.to_string()) {
+
+                let contents = args[1].eval(env)?;
+
+                // If the contents are bytes, write the bytes directly to the file.
+                let result = if let Expression::Bytes(bytes) = contents {
+                    std::fs::write(path, bytes)
+                } else {
+                    // Otherwise, convert the contents to a pretty string and write that.
+                    std::fs::write(path, contents.to_string())
+                };
+
+                match result {
                     Ok(()) => Ok(Expression::None),
-                    Err(_) => Err(Error::CustomError(format!("could not write to file {}", file)))
+                    Err(e) => Err(Error::CustomError(format!("could not write to file {}: {:?}", file, e)))
                 }
             }, "write to a file"),
         }
@@ -1378,14 +1621,15 @@ Dune has the following types in its typesystem:
 1. `Integer`: a signed integer
 2. `Float`: a floating point number
 3. `String`: a string
-4. `Boolean`: a boolean
-5. `None`: a null value
-6. `List`: a list of expressions
-7. `Map`: a table of expressions
-8. `Lambda`: a function
-9. `Macro`: a macro (exactly like a function, but executes within the current scope)
-10. `Builtin`: a builtin function
-11. `Symbol`: the type of a variable name like `x`");
+4. `Bytes`: a list of bytes from a file or from the stdout of a program
+5. `Boolean`: a boolean
+6. `None`: a null value
+7. `List`: a list of expressions
+8. `Map`: a table of expressions
+9. `Lambda`: a function
+10. `Macro`: a macro (exactly like a function, but executes within the current scope)
+11. `Builtin`: a builtin function
+12. `Symbol`: the type of a variable name like `x`");
                     }
                     Expression::Symbol(name) if name == "scripting" => {
                         println!("Hello, welcome to Dune's help macro!
@@ -1465,7 +1709,8 @@ Dune offers the following builtin functions:
 32. `gt`: returns true if the first expression is greater than the second.
 33. `lte`: returns true if the first expression is less than or equal to the second.
 34. `gte`: returns true if the first expression is greater than or equal to the second.
-35. `str`: returns the string representation of an expression.");
+35. `unbind`: unbinds a variable from the current scope.
+36. `str`: returns the string representation of an expression.");
                     }
                     Expression::Symbol(name) if name == "lib" => {
                         println!("Hello, welcome to Dune's help macro!
@@ -1930,24 +2175,23 @@ $ let cat = 'bat
         "change directories",
     );
 
-    // env.define_builtin(
-    //     "prompt",
-    //     |_, env| Ok(Expression::String(format!("{}$ ", env.get_cwd()))),
-    //     "default prompt",
-    // );
-
-    // env.define_builtin(
-    //     "incomplete_prompt",
-    //     |_, env| {
-    //         Ok(Expression::String(format!(
-    //             "{}> ",
-    //             " ".repeat(env.get_cwd().len())
-    //         )))
-    //     },
-    //     "default prompt for incomplete commands",
-    // );
-    // let prompt = cwd -> fmt@bold ((fmt@dark@blue "(dune) ") + (fmt@bold (fmt@dark@green cwd)) + (fmt@bold (fmt@dark@blue "$ ")));
-    // let incomplete_prompt = cwd -> ((len cwd) + (len "(dune) ")) * " " + (fmt@bold (fmt@dark@yellow "> "));
+    env.define_builtin(
+        "unbind",
+        |args, env| {
+            check_exact_args_len("unbind", &args, 1)?;
+            match &args[0] {
+                Expression::Symbol(x) | Expression::String(x) => env.undefine(x),
+                _ => {
+                    return Err(Error::CustomError(format!(
+                        "expected string or symbol, but got {:?}",
+                        args[0]
+                    )))
+                }
+            }
+            Ok(Expression::None)
+        },
+        "unbind a variable from the environment",
+    );
 
     env.define_builtin(
         "chess",
@@ -2030,6 +2274,8 @@ $ let cat = 'bat
         "a fun builtin function for playing chess!",
     );
 
+    parse("let redirect-out = file -> contents -> fs@write file contents")?.eval(&mut env)?;
+
     parse(
         "let prompt = cwd -> \
             fmt@bold ((fmt@dark@blue \"(dune) \") + \
@@ -2038,7 +2284,7 @@ $ let cat = 'bat
     )?
     .eval(&mut env)?;
     parse(
-        r#"let incomplete_prompt = cwd -> \
+        r#"let incomplete_prompt = cwd ->
             ((len cwd) + (len "(dune) ")) * " " + (fmt@bold (fmt@dark@yellow "> "));"#,
     )?
     .eval(&mut env)?;

--- a/src/env.rs
+++ b/src/env.rs
@@ -53,6 +53,10 @@ impl Environment {
             }
     }
 
+    pub fn undefine(&mut self, name: &str) {
+        self.bindings.remove(name);
+    }
+
     pub fn define(&mut self, name: &str, expr: Expression) {
         self.bindings.insert(name.to_string(), expr);
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -165,6 +165,8 @@ fn parse_keyword(input: &str) -> IResult<&str, &str, SyntaxError> {
             tag("&&"),
             tag("||"),
             tag("//"),
+            tag(">>"),
+            tag("|"),
             tag("<"),
             tag(">"),
             tag("+"),
@@ -186,7 +188,8 @@ fn parse_symbol(input: &str) -> IResult<&str, String, SyntaxError> {
         Err(_) => {
             let old_input = input;
 
-            let (input, head) = alt((one_of(ASCII_ALPHA), one_of(ALLOWED_SYMBOL_PUNCTUATION)))(input)?;
+            let (input, head) =
+                alt((one_of(ASCII_ALPHA), one_of(ALLOWED_SYMBOL_PUNCTUATION)))(input)?;
 
             let (input, tail) = many0(alt((
                 one_of(ASCII_ALPHANUMERIC),
@@ -659,6 +662,41 @@ fn parse_apply(input: &str) -> IResult<&str, Expression, SyntaxError> {
 }
 
 fn parse_expression(input: &str) -> IResult<&str, Expression, SyntaxError> {
+    let expr_parser = parse_expression_prec_seven;
+
+    let (input, head) = expr_parser(input)?;
+
+    let (input, list) = many0(pair(
+        delimited(parse_ws, alt((tag("|"), tag(">>"))), parse_ws),
+        expr_parser,
+    ))(input)?;
+
+    if list.is_empty() {
+        return Ok((input, head));
+    }
+
+    let mut args = vec![head];
+    for (op, item) in list {
+        args.push(match op {
+            "|" => item,
+            ">>" => Expression::Apply(
+                Box::new(Expression::Symbol("redirect-out".to_string())),
+                vec![item],
+            ),
+            _ => unreachable!(),
+        })
+    }
+
+    Ok((
+        input,
+        Expression::Group(Box::new(Expression::Apply(
+            Box::new(Expression::Symbol("pipe".to_string())),
+            args,
+        ))),
+    ))
+}
+
+fn parse_expression_prec_seven(input: &str) -> IResult<&str, Expression, SyntaxError> {
     alt((
         parse_for_loop,
         parse_if,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -104,7 +104,7 @@ const ASCII_NONZERO_DIGIT: &str = "123456789";
 const ASCII_DIGIT: &str = "0123456789";
 const ASCII_HEX_DIGIT: &str = "0123456789ABCDEFabcdef";
 
-const ALLOWED_SYMBOL_PUNCTUATION: &'static str = "_+-.~\\/?&<>$%#^:";
+const ALLOWED_SYMBOL_PUNCTUATION: &str = "_+-.~\\/?&<>$%#^:";
 
 pub fn parse_script(input: &str, require_eof: bool) -> IResult<&str, Expression, SyntaxError> {
     let (input, _) = try_parse_ws(input)?;


### PR DESCRIPTION
This PR does a *LOT*. Here's an overview:

1. Calls to lambda functions inherit the current working directory. This is to prevent users from having to write macros, which could inadvertently damage the environment, when called. ***To be clear, the current working directory is the ONLY state that is now inherited by Lambdas. All other states are not inherited.***

Before, when macros were the only way to capture the current environment's current working directory:
```bash
$ # specific macro arguments so they don't overshadow other
$ # variables in the environment when the user calls this.
$ let cp = COPY_SRC ~> COPY_DST ~> fs@write COPY_DST (fs@read COPY_SRC)
```
After:
```bash
$ # this now works as intended outside of the directory the lambda was defined.
$ # verbose argument names aren't needed because they are only defined in the scope
$ # of the lambda itself.
$ let cp = src -> dst -> fs@write dst (fs@read src)
```


2. Implemented the `Bytes` type. This type doesn't have any constructor for the users, but is used as a backup representation for reading/writing files and for piped stdin/out. Whenever a string cannot be read in as valid UTF-8, it is stored as a `Bytes` to prevent any loss in data.
3. Implemented a 1024 character bound on the length of each environment variable. If an environment variable is too large, then Linux will sometimes choke, and say that the argument list is too big for any command. This mitigates that.
4. Implemented the `|` and `>>` operators, which each have the same precedence: the lowest.

```bash
$ cat test.txt | x -> x + "hmm" | rev >> output.txt
$ # expands to
$ pipe (cat test.txt) (x -> x + "hmm") (rev) (redirect-output output.txt)
```
```bash
$ "hmm" >> output.txt
$ # expands to
$ pipe "hmm" (redirect-output output.txt)
```

`redirect-output` is simply defined as:
```rs
let redirect-out = file -> contents -> fs@write file contents
```

5. Implemented the `pipe` builtin function. This takes any number of expressions (>1) as arguments, and pipes the result of each into the next. There are a few things to note about this builtin.

Dune will only capture the standard output of *programs* for piping. Because `echo` is a builtin function, `echo`'s output is not captured. The ***result*** of piping into `echo` is `None`, because `echo` returns `None` after printing its arguments.

Here are a few examples of piping:
```bash
$ "1 + 1" | rev | chars
["1", " ", "+", " ", "1"]
```
The result of the expression `"1 + 1"` is converted to a string, piped into the program `rev`, and then the stdout of `rev` is piped into the function `chars`, which takes a string and returns a list of its characters.

```bash
$ 1 + 2 + 3 | x -> x + 1 | cat
7
```
This pipes the result of `1 + 2 + 3`, which is `6`, into a lambda function which increments that result. The result of the application is then converted into a string, and piped into `cat`.

```bash
$ cat test.txt | rev | bat
───────┬─────────────────────────────────────────
       │ STDIN
───────┼─────────────────────────────────────────
   1   │ mmh
───────┴─────────────────────────────────────────
```
This calls the program `cat` with the arguments `test.txt`, pipes the result into `rev`, which finally pipes the result into `bat`.