### PR TITLE
Use tokenizer for parsing as well

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/bin.rs"
 
 [dependencies]
 chrono = "0.4"
-comment = "0.1.1"
 textwrap = "0.14"
 prettytable-rs = "0.8"
 nom = "7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@ pub use error::*;
 mod parser;
 pub use parser::*;
 
+mod tokens;
+pub use tokens::{Token, TokenKind};
+
 mod tokenizer;
 pub use tokenizer::*;
 

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,0 +1,86 @@
+use std::fmt;
+
+use nom::{InputLength, InputTake};
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct Token<'a> {
+    pub kind: TokenKind,
+    pub text: &'a str,
+}
+
+impl<'a> Token<'a> {
+    pub fn new(kind: TokenKind, text: &'a str) -> Self {
+        Token { kind, text }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TokenKind {
+    Punctuation,
+    Operator,
+    Keyword,
+    StringLiteral,
+    IntegerLiteral,
+    FloatLiteral,
+    BooleanLiteral,
+    Symbol,
+    Whitespace,
+    Comment,
+    Other,
+}
+
+impl fmt::Debug for Token<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}({})", self.kind, self.text)
+    }
+}
+
+impl fmt::Display for Token<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.text)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Tokens<'a>(pub &'a [Token<'a>]);
+
+impl fmt::Display for Tokens<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for t in self.0.iter() {
+            write!(f, "{} ", t)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> std::ops::Deref for Tokens<'a> {
+    type Target = [Token<'a>];
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+impl InputLength for Tokens<'_> {
+    fn input_len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl InputTake for Tokens<'_> {
+    fn take(&self, count: usize) -> Self {
+        Tokens(&self.0[count..])
+    }
+
+    fn take_split(&self, count: usize) -> (Self, Self) {
+        let (a, b) = self.0.split_at(count);
+        (Tokens(a), Tokens(b))
+    }
+}
+
+impl<'a> Tokens<'a> {
+    pub fn skip_n(self, count: usize) -> Self {
+        let (_, rest) = self.0.split_at(count);
+        Tokens(rest)
+    }
+}


### PR DESCRIPTION
This is a rather big change, aiming to simplify parsing. Here's a summary:

* `tokenizer.rs` was refactored to use a struct containing a `TokenKind` instead of an enum. This makes it easier to match on the token's string content

* the tokenizer now also parses comments. This improves syntax highlighting.

* the tokenizer now also parses invalid characters. These are highlighted red.

* the `parse_script` function now tokenizes the input and removes all whitespace and comment tokens, and then proceeds with parsing. This improves the parser for several reasons:
  * no need to account for whitespace in the parser
  * no need to check if keywords or number literals are valid in the parser
  * robustness, separation of concerns
  * consistency: the syntax highlighter is guaranteed to have the same behaviour as the parser
  * no code duplication

* all parser functions in `parser.rs` now accept and return a new `Tokens<'a>` type, which is a wrapper for `&'a [Token<'a>]`.

* usages of the `tag` parser have been replaced with a new `text` parser. That parser checks if the text in the next token matches the provided string. It doesn't check if the `TokenKind` is correct, but that is usually not necessary (for example, a token with the text `"for"` is guaranteed to be a keyword). Note that this was quite error-prone before, because `tag("for")` also parses the text `"forager"`

* to make sure that no invalid numbers are parsed (such as `1.05px`, which is tokenized as `FloatLiteral("1.05")`, `Symbol("px")`), the `parse_script` function checks that "symbol-like" tokens can't appear directly after another without whitespace or punctuation in between.

  "symbol-like" tokens are number literals, bool literals, keywords, operators and symbols, because they can all contain the same characters.

* because the tokenizer parses comments, the `comment` crate was removed from dependencies

P.S. This also slightly changes how `=` is parsed: It is now nowhere required to put spaces around the `=` sign, so `let foo={ bar=baz }` works fine.