### PR TITLE
Add many builtin filesystem functions

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1361,7 +1361,7 @@ fn main() -> Result<(), Error> {
                 }
 
                 Ok(Expression::None)
-            }, "create a directory and all its required parent directories"),
+            }, "create a directory and its parent directories"),
             String::from("rmdir") => Expression::builtin("rmdir", |args, env| {
                 check_exact_args_len("rmdir", &args, 1)?;
                 let cwd = PathBuf::from(env.get_cwd());
@@ -1408,7 +1408,7 @@ fn main() -> Result<(), Error> {
                 let dir = cwd.join(args[0].eval(env)?.to_string());
 
                 list_directory(&dir)
-            }, "retrieve the entries of a given directory as a list of strings"),
+            }, "get a directory's entries as a list of strings"),
             String::from("exists") => Expression::builtin("exists", |args, env| {
                 check_exact_args_len("exists", &args, 1)?;
                 let path = PathBuf::from(env.get_cwd());
@@ -1445,7 +1445,7 @@ fn main() -> Result<(), Error> {
                         Err(_) => Err(Error::CustomError(format!("could not read file {}", file)))
                     }
                 }
-            }, "read a file"),
+            }, "read a file's contents"),
 
             String::from("write") => Expression::builtin("write", |args, env| {
                 check_exact_args_len("write", &args, 2)?;
@@ -1467,7 +1467,7 @@ fn main() -> Result<(), Error> {
                     Ok(()) => Ok(Expression::None),
                     Err(e) => Err(Error::CustomError(format!("could not write to file {}: {:?}", file, e)))
                 }
-            }, "write to a file"),
+            }, "write to a file with some contents"),
         }
         .into(),
     );

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -589,7 +589,7 @@ fn copy_path(src: &Path, dst: &Path) -> Result<(), Error> {
     if src == dst {
         return Ok(());
     }
-    
+
     if dst.exists() {
         return Err(Error::CustomError(format!(
             "destination {} already exists",

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -690,7 +690,7 @@ fn remove_path(path: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-/// Removes a file or directory from the file system.
+/// Returns the paths of entries in a directory as a list of strings.
 fn list_directory(dir: &Path) -> Result<Expression, Error> {
     if dir.is_dir() {
         // The list of paths (as strings) in the directory we will return.

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -586,6 +586,10 @@ fn expr_to_command<'a>(
 
 /// Copy one path to another path.
 fn copy_path(src: &Path, dst: &Path) -> Result<(), Error> {
+    if src == dst {
+        return Ok(());
+    }
+    
     if dst.exists() {
         return Err(Error::CustomError(format!(
             "destination {} already exists",
@@ -632,6 +636,10 @@ fn copy_path(src: &Path, dst: &Path) -> Result<(), Error> {
 
 /// Moves one path to another path.
 fn move_path(src: &Path, dst: &Path) -> Result<(), Error> {
+    if src == dst {
+        return Ok(());
+    }
+
     // If the destination exists, simply throw an error.
     if dst.exists() {
         return Err(Error::CustomError(format!(

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -584,16 +584,21 @@ fn expr_to_command<'a>(
     })
 }
 
-
 /// Copy one path to another path.
 fn copy_path(src: &Path, dst: &Path) -> Result<(), Error> {
     if dst.exists() {
-        return Err(Error::CustomError(format!("destination {} already exists", dst.display())));
+        return Err(Error::CustomError(format!(
+            "destination {} already exists",
+            dst.display()
+        )));
     }
-    
+
     if src.is_dir() {
         if std::fs::create_dir_all(dst).is_err() {
-            return Err(Error::CustomError(format!("could not create directory {}", dst.display())));
+            return Err(Error::CustomError(format!(
+                "could not create directory {}",
+                dst.display()
+            )));
         }
 
         if let Ok(entries) = std::fs::read_dir(src) {
@@ -603,16 +608,24 @@ fn copy_path(src: &Path, dst: &Path) -> Result<(), Error> {
                     let dst_path = dst.join(entry.file_name());
                     copy_path(&path, &dst_path)?;
                 } else {
-                    return Err(Error::CustomError(format!("could not read directory {}", src.display())));
+                    return Err(Error::CustomError(format!(
+                        "could not read directory {}",
+                        src.display()
+                    )));
                 }
             }
         } else {
-            return Err(Error::CustomError(format!("could not create directory {}", dst.display())));
+            return Err(Error::CustomError(format!(
+                "could not create directory {}",
+                dst.display()
+            )));
         }
-    } else {
-        if std::fs::copy(src, dst).is_err() {
-            return Err(Error::CustomError(format!("could not copy file {} to {}", src.display(), dst.display())));
-        }
+    } else if std::fs::copy(src, dst).is_err() {
+        return Err(Error::CustomError(format!(
+            "could not copy file {} to {}",
+            src.display(),
+            dst.display()
+        )));
     }
     Ok(())
 }
@@ -620,12 +633,18 @@ fn copy_path(src: &Path, dst: &Path) -> Result<(), Error> {
 /// Moves one path to another path.
 fn move_path(src: &Path, dst: &Path) -> Result<(), Error> {
     if dst.exists() {
-        return Err(Error::CustomError(format!("destination {} already exists", dst.display())));
+        return Err(Error::CustomError(format!(
+            "destination {} already exists",
+            dst.display()
+        )));
     }
 
     if src.is_dir() {
         if std::fs::create_dir_all(dst).is_err() {
-            return Err(Error::CustomError(format!("could not create directory {}", dst.display())));
+            return Err(Error::CustomError(format!(
+                "could not create directory {}",
+                dst.display()
+            )));
         }
 
         if let Ok(entries) = std::fs::read_dir(src) {
@@ -635,19 +654,30 @@ fn move_path(src: &Path, dst: &Path) -> Result<(), Error> {
                     let dst_path = dst.join(entry.file_name());
                     move_path(&path, &dst_path)?;
                 } else {
-                    return Err(Error::CustomError(format!("could not read directory {}", src.display())));
+                    return Err(Error::CustomError(format!(
+                        "could not read directory {}",
+                        src.display()
+                    )));
                 }
             }
         } else {
-            return Err(Error::CustomError(format!("could not create directory {}", dst.display())));
+            return Err(Error::CustomError(format!(
+                "could not create directory {}",
+                dst.display()
+            )));
         }
         if std::fs::remove_dir(src).is_err() {
-            return Err(Error::CustomError(format!("could not remove directory {}", src.display())));
+            return Err(Error::CustomError(format!(
+                "could not remove directory {}",
+                src.display()
+            )));
         }
-    } else {
-        if std::fs::rename(src, dst).is_err() {
-            return Err(Error::CustomError(format!("could not move file {} to {}", src.display(), dst.display())));
-        }
+    } else if std::fs::rename(src, dst).is_err() {
+        return Err(Error::CustomError(format!(
+            "could not move file {} to {}",
+            src.display(),
+            dst.display()
+        )));
     }
 
     Ok(())
@@ -657,12 +687,16 @@ fn move_path(src: &Path, dst: &Path) -> Result<(), Error> {
 fn remove_path(path: &Path) -> Result<(), Error> {
     if path.is_dir() {
         if std::fs::remove_dir_all(path).is_err() {
-            return Err(Error::CustomError(format!("could not remove directory {}", path.display())));
+            return Err(Error::CustomError(format!(
+                "could not remove directory {}",
+                path.display()
+            )));
         }
-    } else {
-        if std::fs::remove_file(path).is_err() {
-            return Err(Error::CustomError(format!("could not remove file {}", path.display())));
-        }
+    } else if std::fs::remove_file(path).is_err() {
+        return Err(Error::CustomError(format!(
+            "could not remove file {}",
+            path.display()
+        )));
     }
 
     Ok(())
@@ -679,21 +713,30 @@ fn list_directory(dir: &Path) -> Result<Expression, Error> {
                     let file_name_osstring = entry.file_name();
                     result.push(match file_name_osstring.into_string() {
                         Ok(file_name) => file_name,
-                        Err(file_name) => file_name.to_string_lossy().to_string()
+                        Err(file_name) => file_name.to_string_lossy().to_string(),
                     });
                 } else {
-                    return Err(Error::CustomError(format!("could not read entries in {}", dir.display())));
+                    return Err(Error::CustomError(format!(
+                        "could not read entries in {}",
+                        dir.display()
+                    )));
                 }
             }
         } else {
-            return Err(Error::CustomError(format!("could not read directory {}", dir.display())));
+            return Err(Error::CustomError(format!(
+                "could not read directory {}",
+                dir.display()
+            )));
         }
 
         Ok(result.into())
-    } else if dir.is_file(){
-        return Ok(Expression::List(vec![format!("{}", dir.display()).into()]))
+    } else if dir.is_file() {
+        return Ok(Expression::List(vec![format!("{}", dir.display()).into()]));
     } else {
-        return Err(Error::CustomError(format!("{} does not exist", dir.display())))
+        return Err(Error::CustomError(format!(
+            "{} does not exist",
+            dir.display()
+        )));
     }
 }
 
@@ -2370,7 +2413,7 @@ $ let cat = 'bat
                 Expression::None
             } else {
                 x[0].clone()
-            }.into()),
+            }),
             otherwise => Err(Error::CustomError(format!(
                 "cannot get the head of a non-list {}",
                 otherwise
@@ -2386,7 +2429,8 @@ $ let cat = 'bat
                 vec![]
             } else {
                 x[1..].to_vec()
-            }.into()),
+            }
+            .into()),
             otherwise => Err(Error::CustomError(format!(
                 "cannot get the tail of a non-list {}",
                 otherwise

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1616,6 +1616,11 @@ fn main() -> Result<(), Error> {
                 );
                 Ok(Expression::None)
             }, "set the title of the console"),
+            String::from("clear") => Expression::builtin("clear", |args, _| {
+                check_exact_args_len("clear", &args, 1)?;
+                print!("\x1b[2J\x1b[H");
+                Ok(Expression::None)
+            }, "clear the console"),
         }
         .into(),
     );
@@ -2588,6 +2593,7 @@ $ let cat = 'bat
         "a fun builtin function for playing chess!",
     );
 
+    parse("let clear = _ ~> console@clear ()")?.eval(&mut env)?;
     parse("let pwd = _ ~> echo CWD")?.eval(&mut env)?;
     parse("let join = sep -> list -> { let sep = str sep; fn@reduce (x -> y -> x + sep + (str y)) (str list@0) (tail list) }")?.eval(&mut env)?;
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1359,6 +1359,17 @@ fn main() -> Result<(), Error> {
         "fs",
         b_tree_map! {
             String::from("dirs") => dir_tree.into(),
+            String::from("canon") => Expression::builtin("canon", |args, env| {
+                check_exact_args_len("canon", &args, 1)?;
+                let cwd = PathBuf::from(env.get_cwd());
+                let path = cwd.join(args[0].eval(env)?.to_string());
+
+                if let Ok(canon_path) = dunce::canonicalize(&path) {
+                    Ok(canon_path.into_os_string().into_string().unwrap().into())
+                } else {
+                    Err(Error::CustomError(format!("could not canonicalize path {}", path.display())))
+                }
+            }, "resolve, normalize, and absolutize a relative path"),
             String::from("mkdir") => Expression::builtin("mkdir", |args, env| {
                 check_exact_args_len("mkdir", &args, 1)?;
                 let cwd = PathBuf::from(env.get_cwd());


### PR DESCRIPTION
On Windows, it's basically _impossible_ to do anything with the filesystem using the default Dune installation. This is because Windows does not implement `mv`, `cp`, `ls`, ... as programs, but within Powershell and cmd.exe themselves. This adds several builtin functions to `fs` to allow users to manipulate the filesystem regardless of the platform they're on.

This PR includes:
- Copying files and directories (`fs@cp`)
- Moving files and directories (`fs@mv`)
- Creating and removing directories (`fs@mkdir` and `fs@rmdir`)
- Removing files and directories (`fs@rm`)
- Getting the entries of a directory as a list of strings (`fs@ls`)