### PR TITLE
Added guards for broken prelude sections in windows

### DIFF
--- a/.dune-prelude
+++ b/.dune-prelude
@@ -167,53 +167,64 @@ let turnedshrewsay = text -> {
     echo (turnedshrew ());
 };
 
+if os@name != "windows" {
+    let about = _ ~> {
+        echo (
+        widget@joiny
+            (widget@create "About"
+    "          Hello, welcome to " + (fmt@yellow "Dune Shell!") + "
+        Written by: " + (fmt@magenta "http://adam-mcdaniel.net") + "
+    I wrote Dune to be a nice environment for devs while they work! It's a very cozy shell with high customizability, so you can make it how you'd like."
+    50 10)
 
-let about = _ ~> {
-    echo (
-      widget@joiny
-        (widget@create "About"
-  "          Hello, welcome to " + (fmt@yellow "Dune Shell!") + "
-      Written by: " + (fmt@magenta "http://adam-mcdaniel.net") + "
-I wrote Dune to be a nice environment for devs while they work! It's a very cozy shell with high customizability, so you can make it how you'd like."
-  50 10)
+            (widget@joinx
+            (widget@create "Features"
+    "Dune has a wide set of
+    features, it's basically a
+    full blown language!
 
-        (widget@joinx
-          (widget@create "Features"
-"Dune has a wide set of
-features, it's basically a
-full blown language!
+    It supports several uncommon
+    features in a shell, such as:
+    operator overloading,
+    lambdas, macros, quoted
+    expressions like Lisp, and
+    more!
 
-It supports several uncommon
-features in a shell, such as:
-operator overloading,
-lambdas, macros, quoted
-expressions like Lisp, and
-more!
+    Dune's libraries are very
+    extensive. There are
+    libraries for:
 
-Dune's libraries are very
-extensive. There are
-libraries for:
+    ☞ A simple widget system🪟
+    ☞ OS information        💽
+    ☞ Randomness            🔀
+    ☞ Basic math, trig, etc.🧮
+    ☞ File system operations📂
+    ☞ Text color and styling📝
+    ☞ Functional programming🔗
+    ☞ Date and time         🕒
 
-☞ A simple widget system🪟
-☞ OS information        💽
-☞ Randomness            🔀
-☞ Basic math, trig, etc.🧮
-☞ File system operations📂
-☞ Text color and styling📝
-☞ Functional programming🔗
-☞ Date and time         🕒
+    And more!"
+    30 28)
 
-And more!"
-  30 28)
-
-          (widget@joiny
-            (widget@create "About the Author" "I'm a sophomore at\nthe University of\nTennessee🏴󠁵󠁳󠁴󠁮󠁿\nstudying Computer💻\nScience🧪.\n\nI'm extremely \ninterested in\nlanguage design\n& compiler design.\nCheck out my other\nprojects on GitHub:\n\nadam-mcdaniel" 20 18)
-            (widget@create "Cat" (rand@choose CATS) 20 10)
-  )))
-};
+            (widget@joiny
+                (widget@create "About the Author" "I'm a sophomore at\nthe University of\nTennessee🏴󠁵󠁳󠁴󠁮󠁿\nstudying Computer💻\nScience🧪.\n\nI'm extremely \ninterested in\nlanguage design\n& compiler design.\nCheck out my other\nprojects on GitHub:\n\nadam-mcdaniel" 20 18)
+                (widget@create "Cat" (rand@choose CATS) 20 10)
+    )))
+    };
+}
 
 
 let welcomebanner = _ ~> {
+
+
+    let logo = "
+        ██████╗ ██╗   ██╗███╗   ██╗███████╗
+        ██╔══██╗██║   ██║████╗  ██║██╔════╝
+        ██║  ██║██║   ██║██╔██╗ ██║█████╗
+        ██║  ██║██║   ██║██║╚██╗██║██╔══╝
+        ██████╔╝╚██████╔╝██║ ╚████║███████╗
+        ╚═════╝  ╚═════╝ ╚═╝  ╚═══╝╚══════╝
+                                     ";
 
     let logo = "
 
@@ -364,10 +375,12 @@ let cal = _ ~> {
 let welcome = _ ~> {
     welcomebanner ();
     (_ -> {
-        let now = time@now ();
-        echo (widget@joinx
-            (make-calendar now@month now@day now@year)
-            (widget@create "Cat" (rand@choose CATS) 20 10));
+        if os@name != "windows" {
+            let now = time@now ();
+            echo (widget@joinx
+                (make-calendar now@month now@day now@year)
+                (widget@create "Cat" (rand@choose CATS) 20 10));
+        }
     }) ();
 };
 

--- a/src/.dune-prelude
+++ b/src/.dune-prelude
@@ -153,50 +153,51 @@ let turnedshrewsay = text -> {
     echo (turnedshrew ());
 };
 
+if os@name != "windows" {
+    let about = _ ~> {
+        echo (
+        widget@joiny
+            (widget@create "About"
+    "          Hello, welcome to " + (fmt@yellow "Dune Shell!") + "
+        Written by: " + (fmt@magenta "http://adam-mcdaniel.net") + "
+    I wrote Dune to be a nice environment for devs while they work! It's a very cozy shell with high customizability, so you can make it how you'd like."
+    50 10)
 
-let about = _ ~> {
-    echo (
-      widget@joiny
-        (widget@create "About"
-  "          Hello, welcome to " + (fmt@yellow "Dune Shell!") + "
-      Written by: " + (fmt@magenta "http://adam-mcdaniel.net") + "
-I wrote Dune to be a nice environment for devs while they work! It's a very cozy shell with high customizability, so you can make it how you'd like."
-  50 10)
+            (widget@joinx
+            (widget@create "Features"
+    "Dune has a wide set of
+    features, it's basically a
+    full blown language!
 
-        (widget@joinx
-          (widget@create "Features"
-"Dune has a wide set of
-features, it's basically a
-full blown language!
+    It supports several uncommon
+    features in a shell, such as:
+    operator overloading,
+    lambdas, macros, quoted
+    expressions like Lisp, and
+    more!
 
-It supports several uncommon
-features in a shell, such as:
-operator overloading,
-lambdas, macros, quoted
-expressions like Lisp, and
-more!
+    Dune's libraries are very
+    extensive. There are
+    libraries for:
 
-Dune's libraries are very
-extensive. There are
-libraries for:
+    ☞ A simple widget system🪟
+    ☞ OS information        💽
+    ☞ Randomness            🔀
+    ☞ Basic math, trig, etc.🧮
+    ☞ File system operations📂
+    ☞ Text color and styling📝
+    ☞ Functional programming🔗
+    ☞ Date and time         🕒
 
-☞ A simple widget system🪟
-☞ OS information        💽
-☞ Randomness            🔀
-☞ Basic math, trig, etc.🧮
-☞ File system operations📂
-☞ Text color and styling📝
-☞ Functional programming🔗
-☞ Date and time         🕒
+    And more!"
+    30 28)
 
-And more!"
-  30 28)
-
-          (widget@joiny
-            (widget@create "About the Author" "I'm a sophomore at\nthe University of\nTennessee🏴󠁵󠁳󠁴󠁮󠁿\nstudying Computer💻\nScience🧪.\n\nI'm extremely \ninterested in\nlanguage design\n& compiler design.\nCheck out my other\nprojects on GitHub:\n\nadam-mcdaniel" 20 18)
-            (widget@create "Cat" (rand@choose CATS) 20 10)
-  )))
-};
+            (widget@joiny
+                (widget@create "About the Author" "I'm a sophomore at\nthe University of\nTennessee🏴󠁵󠁳󠁴󠁮󠁿\nstudying Computer💻\nScience🧪.\n\nI'm extremely \ninterested in\nlanguage design\n& compiler design.\nCheck out my other\nprojects on GitHub:\n\nadam-mcdaniel" 20 18)
+                (widget@create "Cat" (rand@choose CATS) 20 10)
+    )))
+    };
+}
 
 
 let welcomebanner = _ ~> {
@@ -360,10 +361,12 @@ let cal = _ ~> {
 let welcome = _ ~> {
     welcomebanner ();
     (_ -> {
-        let now = time@now ();
-        echo (widget@joinx
-            (make-calendar now@month now@day now@year)
-            (widget@create "Cat" (rand@choose CATS) 20 10));
+        if os@name != "windows" {
+            let now = time@now ();
+            echo (widget@joinx
+                (make-calendar now@month now@day now@year)
+                (widget@create "Cat" (rand@choose CATS) 20 10));
+        }
     }) ();
 };
 
@@ -388,12 +391,13 @@ let intro = _ ~> {
         shrewsay "Then let's get started!";
         wait ();
 
-        clear ();
-        welcomebanner ();
-        about ();
-        turnedshrewsay "First off, here's some background information about Dune!";
-        wait ();
-
+        if os@name != "windows" {
+            clear ();
+            welcomebanner ();
+            about ();
+            turnedshrewsay "First off, here's some background information about Dune!";
+            wait ();
+        }
 
         clear ();
         welcomebanner ();


### PR DESCRIPTION
Right now, the default prelude and the example prelude seem to fail in windows because of the way Windows handles newline characters (they use `\r\n` instead of `\n`). So for now, I've just put guards around code that breaks (doesn't display properly) in windows.