### PR TITLE
Add default macros for windows

### DIFF
--- a/.dune-prelude
+++ b/.dune-prelude
@@ -32,7 +32,7 @@
 
 
 if os@name == "windows" {
-    let ls = dir ~> fs@ls dir | join "," | echo;
+    let ls = dir ~> fs@ls dir | join "\n" | echo;
     let rm = fs@rm;
     let cp = fs@cp;
     let mv = fs@mv;

--- a/.dune-prelude
+++ b/.dune-prelude
@@ -30,6 +30,18 @@
 #
 # Have fun, scripters!
 
+
+if os@name == "windows" {
+    let ls = dir ~> fs@ls dir | join "," | echo;
+    let rm = fs@rm;
+    let cp = fs@cp;
+    let mv = fs@mv;
+    let mkdir = fs@mkdir;
+    let rmdir = fs@rmdir;
+
+    let cat = fs@read;
+}
+
 console@title "Dune";
 
 let donate = _ ~> {

--- a/src/.dune-prelude
+++ b/src/.dune-prelude
@@ -17,7 +17,7 @@
 #
 
 if os@name == "windows" {
-    let ls = dir ~> fs@ls dir | join "," | echo;
+    let ls = dir ~> fs@ls dir | join "\n" | echo;
     let rm = fs@rm;
     let cp = fs@cp;
     let mv = fs@mv;

--- a/src/.dune-prelude
+++ b/src/.dune-prelude
@@ -16,6 +16,17 @@
 # |_|   |_|  \___|_|\__,_|\__,_|\___|
 #
 
+if os@name == "windows" {
+    let ls = dir ~> fs@ls dir | join "," | echo;
+    let rm = fs@rm;
+    let cp = fs@cp;
+    let mv = fs@mv;
+    let mkdir = fs@mkdir;
+    let rmdir = fs@rmdir;
+
+    let cat = fs@read;
+}
+
 console@title "Dune";
 
 let donate = _ ~> {


### PR DESCRIPTION
This adds a section to the prelude that defines some default macros for commands like `ls`, `cp`, `mv` without the user needing to do it themselves. _This is specifically only implemented for Windows in the prelude._