### PR TITLE
Fixes tab completion in certain circumstances

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -2486,6 +2486,10 @@ $ let cat = 'bat
         |args, env| match args[0].clone().eval(env)? {
             Expression::Symbol(path) | Expression::String(path) => {
                 if let Ok(new_cwd) = dunce::canonicalize(PathBuf::from(env.get_cwd()).join(path)) {
+                    // It's not necessary that this succeeds, because
+                    // Dune does everything relative to the `CWD` bound variable.
+                    // This is mostly to reduce any unintended behavior from
+                    // other libraries like `rustyline`.
                     let _ = std::env::set_current_dir(&new_cwd);
                     env.set_cwd(new_cwd.into_os_string().into_string().unwrap());
                 }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -2487,6 +2487,7 @@ $ let cat = 'bat
         |args, env| match args[0].clone().eval(env)? {
             Expression::Symbol(path) | Expression::String(path) => {
                 if let Ok(new_cwd) = dunce::canonicalize(PathBuf::from(env.get_cwd()).join(path)) {
+                    match std::env::set_current_dir(&new_cwd) { _ => {} }
                     env.set_cwd(new_cwd.into_os_string().into_string().unwrap());
                 }
                 Ok(Expression::None)

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -135,7 +135,7 @@ impl Completer for DuneHelper {
             self.completer.complete(line, pos, ctx)
         } else {
             let mut segment = String::new();
-    
+
             if !line.is_empty() {
                 for (i, ch) in line.chars().enumerate() {
                     if ch.is_whitespace()
@@ -152,24 +152,24 @@ impl Completer for DuneHelper {
                     } else {
                         segment.push(ch);
                     }
-    
+
                     if i == pos {
                         break;
                     }
                 }
-    
+
                 if !segment.is_empty() {
                     path.push(segment.clone());
                 }
             }
-    
+
             let path_str = (path.into_os_string().into_string().unwrap()
                 + if segment.is_empty() { "/" } else { "" })
             .replace("/./", "/")
             .replace("//", "/");
-            let (pos, mut pairs) = self
-                .completer
-                .complete(path_str.as_str(), path_str.len(), ctx)?;
+            let (pos, mut pairs) =
+                self.completer
+                    .complete(path_str.as_str(), path_str.len(), ctx)?;
             for pair in &mut pairs {
                 pair.replacement = String::from(line) + &pair.replacement.replace(&path_str, "");
             }
@@ -2487,7 +2487,7 @@ $ let cat = 'bat
         |args, env| match args[0].clone().eval(env)? {
             Expression::Symbol(path) | Expression::String(path) => {
                 if let Ok(new_cwd) = dunce::canonicalize(PathBuf::from(env.get_cwd()).join(path)) {
-                    match std::env::set_current_dir(&new_cwd) { _ => {} }
+                    let _ = std::env::set_current_dir(&new_cwd);
                     env.set_cwd(new_cwd.into_os_string().into_string().unwrap());
                 }
                 Ok(Expression::None)

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -141,7 +141,6 @@ impl Completer for DuneHelper {
                     if ch.is_whitespace()
                         || ch == ';'
                         || ch == '\''
-                        || ch == '"'
                         || ch == '('
                         || ch == ')'
                         || ch == '{'


### PR DESCRIPTION
Right now, tab completion does not work when the current working directory or the filename being completed contains a space.
This is because `rustyline::completion::FilenameCompleter` uses the current working directory of the program to do this. To fix this, I've made the implementation of `Completer` for `DuneHelper` set the current working directory before attempting completion. This may fail, though. So as a fallback, I've kept the old implementation of tab completion.