### PR TITLE
Implemented optimizations to parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dune"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Adam McDaniel <adam.mcdaniel17@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -9,6 +9,7 @@ pub struct Token<'a> {
 }
 
 impl<'a> Token<'a> {
+    #[inline]
     pub fn new(kind: TokenKind, text: &'a str) -> Self {
         Token { kind, text }
     }
@@ -30,12 +31,14 @@ pub enum TokenKind {
 }
 
 impl fmt::Debug for Token<'_> {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}({})", self.kind, self.text)
     }
 }
 
 impl fmt::Display for Token<'_> {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.text)
     }
@@ -43,6 +46,8 @@ impl fmt::Display for Token<'_> {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Tokens<'a>(pub &'a [Token<'a>]);
+
+// type Tokens<'a> = &'a [Token<'a>];
 
 impl fmt::Display for Tokens<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -56,22 +61,26 @@ impl fmt::Display for Tokens<'_> {
 impl<'a> std::ops::Deref for Tokens<'a> {
     type Target = [Token<'a>];
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         self.0
     }
 }
 
 impl InputLength for Tokens<'_> {
+    #[inline]
     fn input_len(&self) -> usize {
         self.0.len()
     }
 }
 
 impl InputTake for Tokens<'_> {
+    #[inline]
     fn take(&self, count: usize) -> Self {
         Tokens(&self.0[count..])
     }
 
+    #[inline]
     fn take_split(&self, count: usize) -> (Self, Self) {
         let (a, b) = self.0.split_at(count);
         (Tokens(a), Tokens(b))
@@ -79,8 +88,8 @@ impl InputTake for Tokens<'_> {
 }
 
 impl<'a> Tokens<'a> {
+    #[inline]
     pub fn skip_n(self, count: usize) -> Self {
-        let (_, rest) = self.0.split_at(count);
-        Tokens(rest)
+        Tokens(&self.0[count..])
     }
 }


### PR DESCRIPTION
This implements a few optimizations to the parser to prevent a lot of backtracking. With the recent change to the  parser implementation, the default prelude loaded in about 3.8 seconds on my machine. With these slight changes it's brought down to about 0.5 seconds.

1. In the `parse_script_tokens` function, it previously checked if we can parse a `for` loop or an `if` statement without a semicolon. If these failed, then it then moved to `parse_expression`, which also checks if we can parse these two. The new `parse_statement` parses an expression, and if it is not a `for` loop or `if` statement, then requires a semicolon.
2. In the various precedence levels of expressions, it immediately fails if there is a terminating punctuation symbol like `,`, `;`, `)`, `}`, etc. which can never be consumed by an expression.
3. For loops irrecoverably fail when they cannot parse a symbol after `for`.
4. Quoting now has a more intuitive, higher precedence so that `'1 + 2` does not parse as `'(1 + 2)`
5. Applications do not try to parse mathematical expressions like `1 * 2` as functions, which is a waste of time.
6. In `parse_expression_prec_five`, instead of attempting to call `parse_range`, which calls `parse_expression_prec_four` and could then possibly fail, we try to use the `head` and finish the range manually so we do not backtrack.
7. `Tokens::skip_n` does not `split_at`, but instead uses `count..` instead.
8. Several one-line or one-expression functions are now tagged with `#[inline]`