### PR TITLE
Fixed remainder operator

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -76,6 +76,7 @@ fn short_operator(input: &str) -> IResult<&str, &'static str, ()> {
         keyword_tag("+"),
         keyword_tag("-"),
         keyword_tag("*"),
+        keyword_tag("%"),
     ))(input)
 }
 


### PR DESCRIPTION
This adds `%` to the list of short operators so that `5 % 2` does not parse as the application of `5` to the symbol `%` and the number `2`.