### PR TITLE
Better table formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ name = "dune"
 path = "src/bin.rs"
 
 [dependencies]
+terminal_size = "0.1.17"
 chrono = "0.4"
 textwrap = "0.14"
 prettytable-rs = "0.8"

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -8,7 +8,7 @@ use std::{
     process::Command,
 };
 
-use terminal_size::{Width, terminal_size};
+use terminal_size::{terminal_size, Width};
 
 use prettytable::{
     cell,
@@ -242,7 +242,6 @@ impl fmt::Display for Expression {
                 fmt.separator(LinePosition::Intern, LineSeparator::new('─', '┼', '├', '┤'));
                 fmt.separator(LinePosition::Bottom, LineSeparator::new('─', '┴', '└', '┘'));
 
-
                 let width = match terminal_size() {
                     Some((Width(width), _)) => Some(width as usize),
                     _ => None,
@@ -251,20 +250,27 @@ impl fmt::Display for Expression {
                 for (key, val) in exprs {
                     match &val {
                         Self::Builtin(Builtin { help, .. }) => {
-                            t.add_row(row!(key, format!("{}", val), match width {
-                                Some(w) => textwrap::fill(help, w / 6),
-                                None => help.to_string()
-                            }));
+                            t.add_row(row!(
+                                key,
+                                format!("{}", val),
+                                match width {
+                                    Some(w) => textwrap::fill(help, w / 6),
+                                    None => help.to_string(),
+                                }
+                            ));
                         }
                         Self::Map(_) => {
                             t.add_row(row!(key, format!("{}", val)));
                         }
                         _ => {
-                            let s = format!("{}", val);
-                            t.add_row(row!(key, match width {
-                                Some(w) => textwrap::fill(&s, w / 5),
-                                None => s
-                            }));
+                            let formatted = format!("{}", val);
+                            t.add_row(row!(
+                                key,
+                                match width {
+                                    Some(w) => textwrap::fill(&formatted, w / 5),
+                                    None => formatted,
+                                }
+                            ));
                         }
                     }
                 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -8,6 +8,8 @@ use std::{
     process::Command,
 };
 
+use terminal_size::{Width, terminal_size};
+
 use prettytable::{
     cell,
     format::{LinePosition, LineSeparator},
@@ -239,16 +241,30 @@ impl fmt::Display for Expression {
                 fmt.separator(LinePosition::Title, LineSeparator::new('═', '╪', '╞', '╡'));
                 fmt.separator(LinePosition::Intern, LineSeparator::new('─', '┼', '├', '┤'));
                 fmt.separator(LinePosition::Bottom, LineSeparator::new('─', '┴', '└', '┘'));
+
+
+                let width = match terminal_size() {
+                    Some((Width(width), _)) => Some(width as usize),
+                    _ => None,
+                };
+
                 for (key, val) in exprs {
                     match &val {
                         Self::Builtin(Builtin { help, .. }) => {
-                            t.add_row(row!(key, format!("{}", val), textwrap::fill(help, 20)));
+                            t.add_row(row!(key, format!("{}", val), match width {
+                                Some(w) => textwrap::fill(help, w / 6),
+                                None => help.to_string()
+                            }));
                         }
                         Self::Map(_) => {
                             t.add_row(row!(key, format!("{}", val)));
                         }
                         _ => {
-                            t.add_row(row!(key, textwrap::fill(&format!("{}", val), 20)));
+                            let s = format!("{}", val);
+                            t.add_row(row!(key, match width {
+                                Some(w) => textwrap::fill(&s, w / 5),
+                                None => s
+                            }));
                         }
                     }
                 }

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -242,7 +242,7 @@ impl fmt::Display for Expression {
                 for (key, val) in exprs {
                     match &val {
                         Self::Builtin(Builtin { help, .. }) => {
-                            t.add_row(row!(key, format!("{}", val), textwrap::fill(&help, 20)));
+                            t.add_row(row!(key, format!("{}", val), textwrap::fill(help, 20)));
                         }
                         Self::Map(_) => {
                             t.add_row(row!(key, format!("{}", val)));

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -240,10 +240,16 @@ impl fmt::Display for Expression {
                 fmt.separator(LinePosition::Intern, LineSeparator::new('─', '┼', '├', '┤'));
                 fmt.separator(LinePosition::Bottom, LineSeparator::new('─', '┴', '└', '┘'));
                 for (key, val) in exprs {
-                    if let Self::Builtin(Builtin { help, .. }) = &val {
-                        t.add_row(row!(key, format!("{}", val), help));
-                    } else {
-                        t.add_row(row!(key, format!("{}", val)));
+                    match &val {
+                        Self::Builtin(Builtin { help, .. }) => {
+                            t.add_row(row!(key, format!("{}", val), textwrap::fill(&help, 20)));
+                        }
+                        Self::Map(_) => {
+                            t.add_row(row!(key, format!("{}", val)));
+                        }
+                        _ => {
+                            t.add_row(row!(key, textwrap::fill(&format!("{}", val), 20)));
+                        }
                     }
                 }
                 write!(f, "{}", t)


### PR DESCRIPTION
This makes tables much more friendly to the default 80 character wide terminal. Before, tables tried to fit everything on a single line. Now, this uses `textwrap::fill` on the contents of tables which are not nested tables. Nested tables are unchanged.

Before:
![before](https://user-images.githubusercontent.com/28228031/136458700-6a27756b-90d2-4043-ab89-a651c8844817.png)

After:
![image](https://user-images.githubusercontent.com/28228031/136458798-e913a330-4435-41c4-90ad-b8a53780bfe5.png)
![after](https://user-images.githubusercontent.com/28228031/136458732-0c8491be-52e7-4db3-898f-0bfd7343aa1d.png)