### PR TITLE
Don't parse "\/", parse "\u{xxxx}", add tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 pub type Int = i64;
 
 mod expr;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,69 @@
+use crate::{parse_script, parse_tokens, SyntaxError};
+
+fn tokenize_test(input: &str, expected: &str) -> Result<(), nom::Err<SyntaxError>> {
+    let (rest, tokens) = parse_tokens(input)?;
+    assert!(
+        rest.is_empty(),
+        "Not all input was tokenized. Rest: {:?}",
+        rest
+    );
+    let got = format!("{:#?}", tokens);
+    assert_eq!(got.as_str(), expected);
+    Ok(())
+}
+
+fn parse_test(input: &str, expected: &str) -> Result<(), nom::Err<SyntaxError>> {
+    let expr = parse_script(input)?;
+    let got = format!("{:#?}", expr);
+    assert_eq!(got.as_str(), expected);
+    Ok(())
+}
+
+#[test]
+fn tokenize1() -> Result<(), nom::Err<SyntaxError>> {
+    tokenize_test(
+        r#"let a = foo -> bar -> {
+    foo == bar
+}"#,
+        r#"[
+    Keyword(let),
+    Whitespace( ),
+    Symbol(a),
+    Whitespace( ),
+    Punctuation(=),
+    Whitespace( ),
+    Symbol(foo),
+    Whitespace( ),
+    Punctuation(->),
+    Whitespace( ),
+    Symbol(bar),
+    Whitespace( ),
+    Punctuation(->),
+    Whitespace( ),
+    Punctuation({),
+    Whitespace(
+        ),
+    Symbol(foo),
+    Whitespace( ),
+    Operator(==),
+    Whitespace( ),
+    Symbol(bar),
+    Whitespace(
+    ),
+    Punctuation(}),
+]"#,
+    )
+}
+
+#[test]
+fn parse1() -> Result<(), nom::Err<SyntaxError>> {
+    parse_test(r#""String\t\r\n\"""#, r#"{ "String\t\r\n\"" }"#)
+}
+
+#[test]
+fn parse2() -> Result<(), nom::Err<SyntaxError>> {
+    parse_test(
+        r#"let hello = "world\u{21}";"#,
+        r#"{ let hello = "world!" }"#,
+    )
+}

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -2,6 +2,8 @@ use nom::{
     branch::alt,
     bytes::complete::tag,
     combinator::{eof, map},
+    multi::fold_many_m_n,
+    sequence::tuple,
     IResult,
 };
 
@@ -225,20 +227,32 @@ fn ignore_string_inner(mut input: &str) -> IResult<&str, (), SyntaxError> {
 }
 
 fn parse_escape(input: &str) -> IResult<&str, (), SyntaxError> {
-    // const ASCII_HEX_DIGIT: &str = "0123456789ABCDEFabcdef";
+    fn parse_hex_digit(input: &str) -> IResult<&str, &str, SyntaxError> {
+        let mut chars = input.chars();
+        chars
+            .next()
+            .filter(char::is_ascii_hexdigit)
+            .ok_or(nom::Err::Error(SyntaxError::InternalError))?;
+        Ok((chars.as_str(), ""))
+    }
 
     let (input, _) = tag("\\")(input)?;
     let (input, _) = alt((
         tag("\""),
         tag("\\"),
-        tag("/"),
         tag("b"),
         tag("f"),
         tag("n"),
         tag("r"),
         tag("t"),
-        // This doesn't actually work!
-        // map(count(one_of(ASCII_HEX_DIGIT), 4), |_| ""),
+        map(
+            tuple((
+                tag("u{"),
+                fold_many_m_n(1, 5, parse_hex_digit, || "", |_, _| ""),
+                tag("}"),
+            )),
+            |_| "",
+        ),
     ))(input)?;
     Ok((input, ()))
 }
@@ -312,58 +326,5 @@ pub fn parse_tokens(mut input: &str) -> IResult<&str, Vec<Token>, SyntaxError> {
         Ok((input, result))
     } else {
         Err(nom::Err::Failure(SyntaxError::InternalError))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{parse_tokens, SyntaxError};
-
-    fn test(input: &str, expected: &str) -> Result<(), nom::Err<SyntaxError>> {
-        let (rest, tokens) = parse_tokens(input)?;
-        assert!(
-            rest.is_empty(),
-            "Not all input was tokenized. Rest: {:?}",
-            rest
-        );
-        let got = format!("{:#?}", tokens);
-        assert_eq!(expected, got.as_str());
-        Ok(())
-    }
-
-    #[test]
-    fn test1() -> Result<(), nom::Err<SyntaxError>> {
-        test(
-            r#"let a = foo -> bar -> {
-    foo == bar
-}"#,
-            r#"[
-    Keyword(let),
-    Whitespace( ),
-    Symbol(a),
-    Whitespace( ),
-    Punctuation(=),
-    Whitespace( ),
-    Symbol(foo),
-    Whitespace( ),
-    Punctuation(->),
-    Whitespace( ),
-    Symbol(bar),
-    Whitespace( ),
-    Punctuation(->),
-    Whitespace( ),
-    Punctuation({),
-    Whitespace(
-        ),
-    Symbol(foo),
-    Whitespace( ),
-    Operator(==),
-    Whitespace( ),
-    Symbol(bar),
-    Whitespace(
-    ),
-    Punctuation(}),
-]"#,
-        )
     }
 }


### PR DESCRIPTION
* Removes the parser for a `\/` string escape.
* Adds a parser for `\u{xxxx}` string escapes. `xxxx` can be any hexadecimal number with 1-5 digits. It doesn't check if the digits are a valid `char`s (though it probably should).
* Moves the `test` module to a new file and adds a few more tests. They're far from complete as of now.

Closes #19 

I didn't remove `snailquote`, that will have to wait until I have more time.