### PR TITLE
Made widgets cross platform

### DIFF
--- a/.dune-prelude
+++ b/.dune-prelude
@@ -179,14 +179,13 @@ let turnedshrewsay = text -> {
     echo (turnedshrew ());
 };
 
+
 let about = _ ~> {
     echo (
     widget@joiny
         (widget@create "About"
 "          Hello, welcome to " + (fmt@yellow "Dune Shell!") + "
-    Written by: " + (fmt@magenta "http://adam-mcdaniel.net") + "
-I wrote Dune to be a nice environment for devs while they work! It's a very cozy shell with high customizability, so you can make it how you'd like."
-50 10)
+      Written by: http://adam-mcdaniel.net\n\nI wrote Dune to be a nice environment for devs while they work! It's a very cozy shell with high customizability, so you can make it how you'd like." 50 10)
 
             (widget@joinx
             (widget@create "Features"
@@ -222,7 +221,6 @@ And more!"
                 (widget@create "Cat" (rand@choose CATS) 20 10)
     )))
 };
-
 
 let welcomebanner = _ ~> {
 

--- a/.dune-prelude
+++ b/.dune-prelude
@@ -179,15 +179,14 @@ let turnedshrewsay = text -> {
     echo (turnedshrew ());
 };
 
-if os@name != "windows" {
-    let about = _ ~> {
-        echo (
-        widget@joiny
-            (widget@create "About"
-    "          Hello, welcome to " + (fmt@yellow "Dune Shell!") + "
-        Written by: " + (fmt@magenta "http://adam-mcdaniel.net") + "
-    I wrote Dune to be a nice environment for devs while they work! It's a very cozy shell with high customizability, so you can make it how you'd like."
-    50 10)
+let about = _ ~> {
+    echo (
+    widget@joiny
+        (widget@create "About"
+"          Hello, welcome to " + (fmt@yellow "Dune Shell!") + "
+    Written by: " + (fmt@magenta "http://adam-mcdaniel.net") + "
+I wrote Dune to be a nice environment for devs while they work! It's a very cozy shell with high customizability, so you can make it how you'd like."
+50 10)
 
             (widget@joinx
             (widget@create "Features"
@@ -222,8 +221,7 @@ And more!"
                 (widget@create "About the Author" "I'm a sophomore at\nthe University of\nTennessee🏴󠁵󠁳󠁴󠁮󠁿\nstudying Computer💻\nScience🧪.\n\nI'm extremely \ninterested in\nlanguage design\n& compiler design.\nCheck out my other\nprojects on GitHub:\n\nadam-mcdaniel" 20 18)
                 (widget@create "Cat" (rand@choose CATS) 20 10)
     )))
-    };
-}
+};
 
 
 let welcomebanner = _ ~> {
@@ -387,12 +385,10 @@ let cal = _ ~> {
 let welcome = _ ~> {
     welcomebanner ();
     (_ -> {
-        if os@name != "windows" {
-            let now = time@now ();
-            echo (widget@joinx
-                (make-calendar now@month now@day now@year)
-                (widget@create "Cat" (rand@choose CATS) 20 10));
-        }
+        let now = time@now ();
+        echo (widget@joinx
+            (make-calendar now@month now@day now@year)
+            (widget@create "Cat" (rand@choose CATS) 20 10));
     }) ();
 };
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "detached-str"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5c511efd5e4142f1f9ab7b2b667eb24b411c0223b1520f82454ef26e5bbf74"
+
+[[package]]
 name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +345,7 @@ dependencies = [
  "common_macros",
  "criterion",
  "ctrlc",
+ "detached-str",
  "dirs 3.0.2",
  "dunce",
  "nom",

--- a/src/.dune-prelude
+++ b/src/.dune-prelude
@@ -169,9 +169,7 @@ let about = _ ~> {
     widget@joiny
         (widget@create "About"
 "          Hello, welcome to " + (fmt@yellow "Dune Shell!") + "
-    Written by: " + (fmt@magenta "http://adam-mcdaniel.net") + "
-I wrote Dune to be a nice environment for devs while they work! It's a very cozy shell with high customizability, so you can make it how you'd like."
-50 10)
+      Written by: http://adam-mcdaniel.net\n\nI wrote Dune to be a nice environment for devs while they work! It's a very cozy shell with high customizability, so you can make it how you'd like." 50 10)
 
             (widget@joinx
             (widget@create "Features"

--- a/src/.dune-prelude
+++ b/src/.dune-prelude
@@ -164,15 +164,14 @@ let turnedshrewsay = text -> {
     echo (turnedshrew ());
 };
 
-if os@name != "windows" {
-    let about = _ ~> {
-        echo (
-        widget@joiny
-            (widget@create "About"
-    "          Hello, welcome to " + (fmt@yellow "Dune Shell!") + "
-        Written by: " + (fmt@magenta "http://adam-mcdaniel.net") + "
-    I wrote Dune to be a nice environment for devs while they work! It's a very cozy shell with high customizability, so you can make it how you'd like."
-    50 10)
+let about = _ ~> {
+    echo (
+    widget@joiny
+        (widget@create "About"
+"          Hello, welcome to " + (fmt@yellow "Dune Shell!") + "
+    Written by: " + (fmt@magenta "http://adam-mcdaniel.net") + "
+I wrote Dune to be a nice environment for devs while they work! It's a very cozy shell with high customizability, so you can make it how you'd like."
+50 10)
 
             (widget@joinx
             (widget@create "Features"
@@ -207,8 +206,7 @@ And more!"
                 (widget@create "About the Author" "I'm a sophomore at\nthe University of\nTennessee🏴󠁵󠁳󠁴󠁮󠁿\nstudying Computer💻\nScience🧪.\n\nI'm extremely \ninterested in\nlanguage design\n& compiler design.\nCheck out my other\nprojects on GitHub:\n\nadam-mcdaniel" 20 18)
                 (widget@create "Cat" (rand@choose CATS) 20 10)
     )))
-    };
-}
+};
 
 
 let welcomebanner = _ ~> {
@@ -372,12 +370,10 @@ let cal = _ ~> {
 let welcome = _ ~> {
     welcomebanner ();
     (_ -> {
-        if os@name != "windows" {
-            let now = time@now ();
-            echo (widget@joinx
-                (make-calendar now@month now@day now@year)
-                (widget@create "Cat" (rand@choose CATS) 20 10));
-        }
+        let now = time@now ();
+        echo (widget@joinx
+            (make-calendar now@month now@day now@year)
+            (widget@create "Cat" (rand@choose CATS) 20 10));
     }) ();
 };
 
@@ -402,13 +398,11 @@ let intro = _ ~> {
         shrewsay "Then let's get started!";
         wait ();
 
-        if os@name != "windows" {
-            clear ();
-            welcomebanner ();
-            about ();
-            turnedshrewsay "First off, here's some background information about Dune!";
-            wait ();
-        }
+        clear ();
+        welcomebanner ();
+        about ();
+        turnedshrewsay "First off, here's some background information about Dune!";
+        wait ();
 
         clear ();
         welcomebanner ();

--- a/src/binary/init/mod.rs
+++ b/src/binary/init/mod.rs
@@ -105,6 +105,23 @@ pub fn init(env: &mut Environment) {
     );
 
     env.define_builtin(
+        "debug",
+        |args, env| {
+            for (i, arg) in args.iter().enumerate() {
+                let x = arg.clone().eval(env)?;
+                if i < args.len() - 1 {
+                    print!("{:?} ", x)
+                } else {
+                    println!("{:?}", x)
+                }
+            }
+
+            Ok(Expression::None)
+        },
+        "print the debug representation of the arguments and a newline",
+    );
+
+    env.define_builtin(
         "println",
         |args, env| {
             for (i, arg) in args.iter().enumerate() {

--- a/src/binary/init/widget_module.rs
+++ b/src/binary/init/widget_module.rs
@@ -177,5 +177,10 @@ fn joiny(args: Vec<Expression>, env: &mut Environment) -> Result<Expression, Err
         }
     }
 
-    Ok(string_args.into_iter().map(|x| x.replace('\r', "")).collect::<Vec<_>>().join("\n").into())
+    Ok(string_args
+        .into_iter()
+        .map(|x| x.replace('\r', ""))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .into())
 }

--- a/src/binary/init/widget_module.rs
+++ b/src/binary/init/widget_module.rs
@@ -61,7 +61,7 @@ fn create(args: Vec<Expression>, env: &mut Environment) -> Result<Expression, Er
 
         let mut lines = 1;
         let mut i = 0;
-        for ch in text.chars() {
+        for ch in text.replace('\r', "").chars() {
             if i == 0 {
                 result.push(' ');
                 i += 1;
@@ -141,7 +141,7 @@ fn joinx(args: Vec<Expression>, env: &mut Environment) -> Result<Expression, Err
 
     for line_n in 0..height {
         for arg in &string_args {
-            result += &arg[line_n];
+            result += &arg[line_n].replace('\r', "");
         }
         result += "\n";
     }
@@ -177,5 +177,5 @@ fn joiny(args: Vec<Expression>, env: &mut Environment) -> Result<Expression, Err
         }
     }
 
-    Ok(string_args.join("\n").into())
+    Ok(string_args.into_iter().map(|x| x.replace('\r', "")).collect::<Vec<_>>().join("\n").into())
 }


### PR DESCRIPTION
Before, widgets had problems on windows due to the `'\r'` character. Now, we remove the `'\r'` character before manipulating the user's text into a formatted block of text.