### PR TITLE
Made minimum line number reported in error 1

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use detached_str::{Str, StrSlice};
 
-use core::{fmt, cmp::max};
+use core::{cmp::max, fmt};
 
 use crate::Diagnostic;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use detached_str::{Str, StrSlice};
 
-use core::fmt;
+use core::{fmt, cmp::max};
 
 use crate::Diagnostic;
 
@@ -151,7 +151,7 @@ fn print_error_lines(
     let line_before = before.lines().next_back().unwrap_or_default();
     let line_after = after.lines().next().unwrap_or_default();
 
-    let first_line_number = before.lines().count();
+    let first_line_number = max(before.lines().count(), 1);
 
     writeln!(f, "      |")?;
 


### PR DESCRIPTION
Before, there was a slight quirk with the line number being reported as zero in some edge cases, but properly when there are multiple lines. See the example below.
![image](https://user-images.githubusercontent.com/28228031/137021517-e0107a1f-caa1-45c5-899c-5ee420fd60a5.png)

I just put a guard around the reported line number to make sure that the minimum line number reported is `1`.
![image](https://user-images.githubusercontent.com/28228031/137021666-3ff462f5-8408-4a51-8e58-757bca7163ac.png)
