### PR TITLE
Allow operators as symbols in various places

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -538,7 +538,7 @@ fn main() -> Result<(), Error> {
     )?
     .eval(&mut env)?;
 
-    parse("let redirect-out = file -> contents -> fs@write file contents")?.eval(&mut env)?;
+    parse("let >> = file -> contents -> fs@write file contents")?.eval(&mut env)?;
 
     parse(
         "let prompt = cwd -> \

--- a/src/binary/init/mod.rs
+++ b/src/binary/init/mod.rs
@@ -158,7 +158,7 @@ pub fn init(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "range",
+        "to",
         |args, env| {
             if args.len() == 2 {
                 match (args[0].clone().eval(env)?, args[1].clone().eval(env)?) {

--- a/src/binary/init/operator_module.rs
+++ b/src/binary/init/operator_module.rs
@@ -2,7 +2,7 @@ use dune::{Environment, Error, Expression};
 
 pub fn add_to(env: &mut Environment) {
     env.define_builtin(
-        "__add__",
+        "+",
         |args, env| {
             let mut result = args[0].clone().eval(env)?;
             for arg in &args[1..] {
@@ -22,7 +22,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__sub__",
+        "-",
         |args, env| {
             let mut result = args[0].clone().eval(env)?;
             for arg in &args[1..] {
@@ -42,7 +42,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__mul__",
+        "*",
         |args, env| {
             let mut result = args[0].clone().eval(env)?;
             for arg in &args[1..] {
@@ -62,7 +62,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__div__",
+        "//",
         |args, env| {
             let mut result = args[0].clone().eval(env)?;
             for arg in &args[1..] {
@@ -82,7 +82,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__rem__",
+        "%",
         |args, env| {
             let mut result = args[0].clone().eval(env)?;
             for arg in &args[1..] {
@@ -102,7 +102,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__and__",
+        "&&",
         |args, env| {
             Ok(Expression::Boolean(
                 args.into_iter()
@@ -116,7 +116,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__or__",
+        "||",
         |args, env| {
             Ok(Expression::Boolean(
                 args.into_iter()
@@ -130,7 +130,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__not__",
+        "!",
         |args, env| {
             Ok(Expression::Boolean(
                 args.into_iter()
@@ -144,7 +144,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__eq__",
+        "==",
         |args, env| {
             Ok(Expression::Boolean(
                 args[0].eval(env)? == args[1].eval(env)?,
@@ -154,7 +154,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__neq__",
+        "!=",
         |args, env| {
             Ok(Expression::Boolean(
                 args[0].eval(env)? != args[1].eval(env)?,
@@ -164,7 +164,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__lt__",
+        "<",
         |args, env| {
             Ok(Expression::Boolean(
                 args[0].clone().eval(env)? < args[1].clone().eval(env)?,
@@ -174,7 +174,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__lte__",
+        "<=",
         |args, env| {
             Ok(Expression::Boolean(
                 args[0].clone().eval(env)? <= args[1].clone().eval(env)?,
@@ -184,7 +184,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__gt__",
+        ">",
         |args, env| {
             Ok(Expression::Boolean(
                 args[0].clone().eval(env)? > args[1].clone().eval(env)?,
@@ -194,7 +194,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__gte__",
+        ">=",
         |args, env| {
             Ok(Expression::Boolean(
                 args[0].clone().eval(env)? >= args[1].clone().eval(env)?,
@@ -204,7 +204,7 @@ pub fn add_to(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "__idx__",
+        "@",
         |args, env| {
             let mut val = args[0].eval(env)?;
             for arg in &args[1..] {

--- a/src/binary/init/pipe_module.rs
+++ b/src/binary/init/pipe_module.rs
@@ -9,11 +9,7 @@ pub fn add_to(env: &mut Environment) {
     // This is a special form that takes a list of expressions
     // and interprets them as a commands.
     // It pipes the result of each command to the next one.
-    env.define_builtin(
-        "__pipe__",
-        pipe_builtin,
-        "pipe input through a list of commands",
-    );
+    env.define_builtin("|", pipe_builtin, "pipe input through a list of commands");
 }
 
 fn pipe_builtin(args: Vec<Expression>, env: &mut Environment) -> Result<Expression, Error> {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -151,7 +151,7 @@ let x # test
 #[test]
 fn tokenize_symbols_and_operators() {
     tokenize_test(
-        r#"to == != >= <= && || // < > + - * % _+-.~\/?&<>$%^: abcXYZ"#,
+        r#"to == != >= <= && || // < > + - * % | >> @ _+-.~\/?&<>$%^: abcXYZ"#,
         r#"[
     Operator(0..2),
     Whitespace(2..3),
@@ -181,9 +181,15 @@ fn tokenize_symbols_and_operators() {
     Whitespace(33..34),
     Operator(34..35),
     Whitespace(35..36),
-    Symbol(36..51),
-    Whitespace(51..52),
-    Symbol(52..58),
+    Operator(36..37),
+    Whitespace(37..38),
+    Operator(38..40),
+    Whitespace(40..41),
+    Operator(41..42),
+    Whitespace(42..43),
+    Symbol(43..58),
+    Whitespace(58..59),
+    Symbol(59..65),
 ]"#,
     );
 }
@@ -225,5 +231,13 @@ fn parse2() -> Result<(), nom::Err<SyntaxError>> {
     parse_test(
         r#"let hello = "world\u{21}";"#,
         r#"{ let hello = "world!" }"#,
+    )
+}
+
+#[test]
+fn parse3() -> Result<(), nom::Err<SyntaxError>> {
+    parse_test(
+        r#"let + = a -> b -> c -> (+ a b c)"#,
+        r#"{ let + = a -> b -> c -> (+ a b c) }"#,
     )
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -81,13 +81,10 @@ fn any_punctuation(input: Input<'_>) -> TokenizationResult<'_> {
         punctuation_tag("]"),
         punctuation_tag("{"),
         punctuation_tag("}"),
-        punctuation_tag("@"),
         punctuation_tag("\'"),
         punctuation_tag(","),
         punctuation_tag(";"),
         punctuation_tag("="),
-        keyword_tag("|"),  // must be surrounded by whitespace
-        keyword_tag(">>"), // `>>foo` is also a valid symbol
         keyword_tag("->"), // `->foo` is also a valid symbol
         keyword_tag("~>"), // `~>foo` is also a valid symbol
     ))(input)
@@ -103,6 +100,7 @@ fn long_operator(input: Input<'_>) -> TokenizationResult<'_> {
         keyword_tag("&&"),
         keyword_tag("||"),
         keyword_tag("//"),
+        keyword_tag(">>"),
     ))(input)
 }
 
@@ -114,6 +112,9 @@ fn short_operator(input: Input<'_>) -> TokenizationResult<'_> {
         keyword_tag("-"),
         keyword_tag("*"),
         keyword_tag("%"),
+        keyword_tag("|"),
+        punctuation_tag("@"),
+        punctuation_tag("!"),
     ))(input)
 }
 


### PR DESCRIPTION
This allows operators such as `+` or `%` in a few places where previously only symbols were allowed:

* In variable name in assignments: `let + = "hello"`
* As function name in a function call: `+ 3 4 (- 2 5)`
* In map keys and values: `let foo = { +=% }`
* As indices: `foo@+`

In all other places, the operator must be wrapped in parentheses:

```
echo 3 (+) 5  # prints the integer 3, the addition operator and the integer 5
(+)@-         # accesses the key `-` of the object `+`
```

Operators can still be used in infix position:

```
> 3 + 5 == (+ 3 5)
True
> fmt @ dark @ blue == (@ fmt dark blue)
True
```

`@`, `|` and `>>` are turned into operators. They were classified as punctuation before, which doesn't make sense because unlike punctuation they can be overloaded.

`!` is added, which I apparently forgot to add to the tokenizer.

Builtin operators are renamed to the respective symbol. E.g. `__add__` is now `+`, and `redirect-to` is now `>>`.