### PR TITLE
Added keys and vals functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
 name = "dune"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "chess-engine",
  "chrono",

--- a/src/binary/init/mod.rs
+++ b/src/binary/init/mod.rs
@@ -263,9 +263,7 @@ pub fn init(env: &mut Environment) {
 
     env.define_builtin(
         "environment",
-        |_, env| {
-            Ok(env.bindings.clone().into())
-        },
+        |_, env| Ok(env.bindings.clone().into()),
         "get a table of the environment",
     );
 

--- a/src/binary/init/mod.rs
+++ b/src/binary/init/mod.rs
@@ -238,6 +238,38 @@ pub fn init(env: &mut Environment) {
     );
 
     env.define_builtin(
+        "keys",
+        |args, env| match args[0].eval(env)? {
+            Expression::Map(m) => Ok(m.into_keys().collect::<Vec<_>>().into()),
+            otherwise => Err(Error::CustomError(format!(
+                "cannot get the keys of {}",
+                otherwise
+            ))),
+        },
+        "get the list of keys in a table",
+    );
+
+    env.define_builtin(
+        "vals",
+        |args, env| match args[0].eval(env)? {
+            Expression::Map(m) => Ok(Expression::List(m.into_values().collect::<Vec<_>>().into())),
+            otherwise => Err(Error::CustomError(format!(
+                "cannot get the values of {}",
+                otherwise
+            ))),
+        },
+        "get the list of values in a table",
+    );
+
+    env.define_builtin(
+        "environment",
+        |_, env| {
+            Ok(env.bindings.clone().into())
+        },
+        "get a table of the environment",
+    );
+
+    env.define_builtin(
         "len",
         |args, env| match args[0].eval(env)? {
             Expression::Map(m) => Ok(Expression::Integer(m.len() as Int)),

--- a/src/binary/init/mod.rs
+++ b/src/binary/init/mod.rs
@@ -252,7 +252,7 @@ pub fn init(env: &mut Environment) {
     env.define_builtin(
         "vals",
         |args, env| match args[0].eval(env)? {
-            Expression::Map(m) => Ok(Expression::List(m.into_values().collect::<Vec<_>>().into())),
+            Expression::Map(m) => Ok(m.into_values().collect::<Vec<_>>().into()),
             otherwise => Err(Error::CustomError(format!(
                 "cannot get the values of {}",
                 otherwise

--- a/src/binary/init/mod.rs
+++ b/src/binary/init/mod.rs
@@ -262,9 +262,9 @@ pub fn init(env: &mut Environment) {
     );
 
     env.define_builtin(
-        "environment",
+        "vars",
         |_, env| Ok(env.bindings.clone().into()),
-        "get a table of the environment",
+        "get a table of the defined variables",
     );
 
     env.define_builtin(


### PR DESCRIPTION
Added `keys` and `vals`, which get the list of keys and list of values from a table, respectively. I also added the `environment` builtin, which gets the bound symbols and their values as a table.