### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Build and upload binaries to release
+
+# copied and modified from https://github.com/Aloso/colo/blob/main/.github/workflows/release.yml
+
+# https://eugene-babichenko.github.io/blog/2020/05/09/github-actions-cross-platform-auto-releases/
+# https://mateuscosta.me/rust-releases-with-github-actions
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.*'
+
+jobs:
+  create_release:
+    name: Create release
+    runs-on: ubuntu-latest
+    # Note this. We are going to use that in further jobs.
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Set variables
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+          body: |
+            This is a new release of dune. [Read the changelog here](https://github.com/adam-mcdaniel/dune/blob/${{ steps.vars.outputs.tag }}/CHANGELOG.md).
+
+            If you're running on Linux, macOS or Windows, you can probably use one of the binaries below.
+
+  release_assets:
+    name: Release assets
+    needs: create_release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            file_ending: ''
+          - os: macos-latest
+            platform: macos
+            file_ending: ''
+          - os: windows-latest
+            platform: windows
+            file_ending: '.exe'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Print information
+        run: |
+          rustup show active-toolchain
+          rustc --version
+          cargo tree
+
+      - name: Set variables
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+
+      - name: Build project
+        run: cargo build --release --locked
+
+      - name: Upload release assets
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_name: dune_${{ matrix.platform }}_${{ steps.vars.outputs.tag }}${{ matrix.file_ending }}
+          asset_path: target/release/dunesh${{ matrix.file_ending }}
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
Adds a GitHub workflow that creates a new release and builds binaries for Linux, Windows and Mac whenever a new git tag is pushed.

Use it like this:

```sh
git tag v2.0   # create a tag for version 2.0
git push v2.0  # push the tag
```

This will trigger the workflow. After a moment, a new release should appear on https://github.com/adam-mcdaniel/dune/releases. The text of the release can be edited manually.

When the workflow is finished, the release should include artifacts, which are binaries for Windows, Linux and MacOS. If this should fail for some reason, the artifacts can also be added manually.