### PR TITLE
Optimizations, correctly handle stdout

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -56,9 +56,7 @@ fn new_editor(env: &Environment) -> Editor<DuneHelper> {
     rl
 }
 
-fn strip_ansi_escapes(text: impl ToString) -> String {
-    let text = text.to_string();
-
+fn strip_ansi_escapes(text: &str) -> String {
     let mut result = String::new();
     let mut is_in_escape = false;
     for ch in text.chars() {
@@ -77,15 +75,17 @@ fn strip_ansi_escapes(text: impl ToString) -> String {
     result
 }
 
-fn readline(prompt: impl ToString, rl: &mut Editor<DuneHelper>) -> String {
-    let prompt = prompt.to_string();
+fn readline(prompt: String, rl: &mut Editor<DuneHelper>) -> String {
     loop {
+        let prompt = prompt.clone();
+        let stripped = strip_ansi_escapes(&prompt);
+
         // This MUST be called to update the prompt.
         if let Some(helper) = rl.helper_mut() {
-            helper.set_prompt(&prompt);
+            helper.set_prompt(prompt);
         }
 
-        match rl.readline(&strip_ansi_escapes(&prompt)) {
+        match rl.readline(&stripped) {
             Ok(line) => return line,
             Err(ReadlineError::Interrupted) => {
                 return String::new();
@@ -111,8 +111,8 @@ impl DuneHelper {
     /// This method MUST be called to update the prompt.
     /// If this method is not called, the prompt will not
     /// update.
-    fn set_prompt(&mut self, prompt: impl ToString) {
-        self.colored_prompt = prompt.to_string();
+    fn set_prompt(&mut self, prompt: String) {
+        self.colored_prompt = prompt;
     }
 
     fn update_env(&mut self, env: &Environment) {
@@ -189,7 +189,7 @@ fn syntax_highlight(line: &str) -> String {
                 is_colored = true;
                 result.push_str(b);
             }
-            (TokenKind::Punctuation, o @ ("@" | "\'" | "=" | "|" | ">>" | "->" | "~>")) => {
+            (TokenKind::Punctuation, o @ ("\'" | "=" | "->" | "~>")) => {
                 result.push_str("\x1b[96m");
                 is_colored = true;
                 result.push_str(o);
@@ -445,7 +445,7 @@ fn repl(
     loop {
         let mut env = atomic_env.lock().unwrap();
         let mut rl = atomic_rl.lock().unwrap();
-        let cwd = env.get_cwd();
+        let cwd = env.get_cwd().to_string();
         // let prompt = format!("{}", Expression::Apply(Box::new(env.get("prompt").unwrap()), vec![env.get_cwd().into()]).eval(&mut env)?);
 
         let prompt = Expression::Apply(
@@ -457,11 +457,12 @@ fn repl(
                 }
                 .to_string(),
             )),
-            vec![cwd.clone().into()],
+            vec![cwd.to_string().into()],
         )
         .eval(&mut env)
         .unwrap_or_else(|_| format!("{}$ ", cwd).into())
         .to_string();
+
         rl.helper_mut()
             .expect("No helper")
             .set_prompt(prompt.clone());
@@ -481,10 +482,8 @@ fn repl(
                 let val = expr.eval(&mut env);
                 match val.clone() {
                     Ok(Expression::Symbol(name)) => {
-                        if let Err(e) =
-                            Expression::Apply(Box::new(Expression::Symbol(name)), vec![])
-                                .eval(&mut env)
-                        {
+                        let apply = Expression::Apply(Box::new(Expression::Symbol(name)), vec![]);
+                        if let Err(e) = apply.eval(&mut env) {
                             eprintln!("{}", e)
                         }
                     }

--- a/src/binary/init/fmt_module.rs
+++ b/src/binary/init/fmt_module.rs
@@ -5,7 +5,7 @@ pub fn get() -> Expression {
     (b_tree_map! {
         String::from("strip") => Expression::builtin("strip", |args, env| {
             super::check_exact_args_len("strip", &args, 1)?;
-            Ok(crate::strip_ansi_escapes(args[0].eval(env)?).into())
+            Ok(crate::strip_ansi_escapes(&args[0].eval(env)?.to_string()).into())
         }, "strips all colors and styling from a string"),
 
         String::from("wrap") => Expression::builtin("wrap", wrap,

--- a/src/binary/init/widget_module.rs
+++ b/src/binary/init/widget_module.rs
@@ -114,17 +114,16 @@ fn joinx(args: Vec<Expression>, env: &mut Environment) -> Result<Expression, Err
         match arg.eval(env)? {
             Expression::String(s) => {
                 let lines = s.lines().map(ToString::to_string).collect::<Vec<String>>();
-                string_args.push(lines.clone());
+                let lines_len = lines.len();
+                string_args.push(lines);
 
                 height = string_args[0].len();
 
-                if height != lines.len() {
+                if height != lines_len {
                     return Err(Error::CustomError(format!(
                         "Heights of horizontally added widgets must be equal, \
                             first widget height={}, {}th widget height={}",
-                        height,
-                        i,
-                        lines.len()
+                        height, i, lines_len
                     )));
                 }
             }


### PR DESCRIPTION
Fixes #71. Closes #70.

This PR adds a variable to the environment that tracks whether the currently evaluated expression's output should be printed directly or stored in a string. This is done to allow things like `let x = which vim` or `"[" + (hostname ()) + "]"`.

I also refactored some parts to clone objects less often, allocate fewer `Box`es and `Vec`s and use `.to_string()` instead of `format!("{}", ..)` when possible.

I replaced occurrences of `impl ToString` with `impl Into<String>` or just `String`, because `ToString` uses the `Display` implementation which might be more expensive.