### PR TITLE
Feather/linesplit and line continue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 history.txt
 *.cast
+/target*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+### [0.2.0-lineclip] - 2025-3-29
+- use `\n` or `;` to split statement. which means you don't have to type `;` to every lineend.
+- use `\\n` to continue a line.
 
 ## [Unreleased]
 

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -273,12 +273,12 @@ fn syntax_highlight(line: &str) -> String {
             (TokenKind::Whitespace, w) => {
                 result.push_str(w);
             }
-            (TokenKind::NewLine, w) => {
+            (TokenKind::LineBreak, w) => {
                 result.push_str(w);
             }
-            (TokenKind::LineContinuation, w) => {
-                result.push_str(w);
-            }
+            // (TokenKind::LineContinuation, w) => {
+            //     result.push_str(w);
+            // }
             (TokenKind::Comment, w) => {
                 result.push_str("\x1b[38;5;247m");
                 is_colored = true;

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -273,6 +273,12 @@ fn syntax_highlight(line: &str) -> String {
             (TokenKind::Whitespace, w) => {
                 result.push_str(w);
             }
+            (TokenKind::NewLine, w) => {
+                result.push_str(w);
+            }
+            (TokenKind::LineContinuation, w) => {
+                result.push_str(w);
+            }
             (TokenKind::Comment, w) => {
                 result.push_str("\x1b[38;5;247m");
                 is_colored = true;
@@ -546,14 +552,14 @@ fn run_file(path: PathBuf, env: &mut Environment) -> Result<Expression, Error> {
 fn main() -> Result<(), Error> {
     let matches = App::new(
         r#"
-        888                            
-        888                            
-        888                            
-    .d88888 888  888 88888b.   .d88b.  
-   d88" 888 888  888 888 "88b d8P  Y8b 
-   888  888 888  888 888  888 88888888 
-   Y88b 888 Y88b 888 888  888 Y8b.     
-    "Y88888  "Y88888 888  888  "Y8888  
+        888
+        888
+        888
+    .d88888 888  888 88888b.   .d88b.
+   d88" 888 888  888 888 "88b d8P  Y8b
+   888  888 888  888 888  888 88888888
+   Y88b 888 Y88b 888 888  888 Y8b.
+    "Y88888  "Y88888 888  888  "Y8888
    "#,
     )
     .author(crate_authors!())

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -105,6 +105,8 @@ pub enum TokenKind {
     BooleanLiteral,
     Symbol,
     Whitespace,
+    NewLine,          //add newline
+    LineContinuation, //add linecontinue
     Comment,
 }
 

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -105,8 +105,8 @@ pub enum TokenKind {
     BooleanLiteral,
     Symbol,
     Whitespace,
-    NewLine,          //add newline
-    LineContinuation, //add linecontinue
+    LineBreak, //add newline
+    // LineContinuation, //add linecontinue
     Comment,
 }
 


### PR DESCRIPTION
- optional choose `;` or `linebreak` to split a statement. linebreak was automaticlly analyzied when a new line start. but except a new lined followed these chars: 
`'{' | '(' | '[' | ',' | '>' | '=' | ';' | '\n' | '\\'`
- added `\` to the end of a line to contiue a line.

### tested with following cases:
```bash
# 测试1: 纯换行符分割
let a = 1
let b = a + 2
echo b
echo "1 pass"

# 测试2: 分号结尾
let c = 3; let d = c * 4;
echo d
echo "2 pass"

# 测试3: 混合分割
let e = 5;
let f = e + 6  # 无分号
let g = f // 7;
echo g
echo "3 pass"

# 测试4: 控制结构自动终止
if g > 0 {
    echo "Positive"
}

echo "pass 4"

let sum =0
for i in 0 to 10 {
    echo i
    let sum = sum + i
}
echo sum
echo "pass 5"

# 测试5: 多行字符串
let logo = "
    ██╗  ██╗███████╗
    ██║  ██║██╔════╝
    ███████║█████╗  
    ██╔══██║██╔══╝  
    ██║  ██║███████╗
    ╚═╝  ╚═╝╚══════╝
"
echo logo
echo "pass 6"

# 测试6: 续行符连接
let long_expr = 1 + 2 + \
                3 + 4 + \
                5
echo long_expr                

echo "pass all"
# 测试7: 文件末尾装饰换行符


```